### PR TITLE
Feature/documentation fixes

### DIFF
--- a/app/code/community/Aoe/Queue/Helper/Data.php
+++ b/app/code/community/Aoe/Queue/Helper/Data.php
@@ -1,12 +1,15 @@
 <?php
-
 /**
+ * AOE Queue - Queue implementation for Magento based on Zend Queue
+ *
  * Data helper
  *
- * @author Fabrizio Branca
- * @since 2012-11-07
+ * @category Mage
+ * @package  Aoe_Queue
+ * @author   Fabrizio Branca
+ * @since    2012-11-07
  */
-class Aoe_Queue_Helper_Data extends Mage_Core_Helper_Abstract {
-
+class Aoe_Queue_Helper_Data extends Mage_Core_Helper_Abstract
+{
 
 }

--- a/app/code/community/Aoe/Queue/Model/Adapter/Db.php
+++ b/app/code/community/Aoe/Queue/Model/Adapter/Db.php
@@ -1,8 +1,13 @@
 <?php
-
 /**
- * @author Lee Saferite <lee.saferite@aoe.com>
- * @since  2014-08-14
+ * AOE Queue - Queue implementation for Magento based on Zend Queue
+ *
+ * Database adapter
+ * 
+ * @category Mage
+ * @package  Aoe_Queue
+ * @author   Lee Saferite <lee.saferite@aoe.com>
+ * @since    2014-08-14
  */
 class Aoe_Queue_Model_Adapter_Db extends Zend_Queue_Adapter_Db
 {
@@ -14,7 +19,7 @@ class Aoe_Queue_Model_Adapter_Db extends Zend_Queue_Adapter_Db
      *
      * @return self
      *
-     * @throws Zend_Queue_Exception
+     * @throws Zend_Queue_Exception If requires options are not set
      */
     public function __construct($options, Zend_Queue $queue = null)
     {
@@ -45,7 +50,7 @@ class Aoe_Queue_Model_Adapter_Db extends Zend_Queue_Adapter_Db
         $queueTable = $this->_options['dbQueueTable'];
         $messageTable = $this->_options['dbMessageTable'];
 
-        $this->_queueTable = new Zend_Db_Table(array('db' => $db, 'name' => $queueTable, 'primary' => 'queue_id'));
+        $this->_queueTable   = new Zend_Db_Table(array('db' => $db, 'name' => $queueTable, 'primary' => 'queue_id'));
         $this->_messageTable = new Zend_Db_Table(array('db' => $db, 'name' => $messageTable, 'primary' => 'message_id'));
     }
 }

--- a/app/code/community/Aoe/Queue/Model/Cron.php
+++ b/app/code/community/Aoe/Queue/Model/Cron.php
@@ -17,12 +17,12 @@ class Aoe_Queue_Model_Cron
      */
     public function processQueue()
     {
-        $starttime = microtime(true);
-        $maxRuntime = 60; // TODO: read from configuration
+        $starttime  = microtime(true);
+        $maxRuntime = Mage::getStoreConfig('system/aoe_queue/max_runtime');
 
         $queueNames = Mage::getSingleton('aoe_queue/queue')->getQueues();
 
-        /* @var $queues Aoe_Queue_Model_Queue[] */
+        /* @var $queues Aoe_Queue_Model_Queue */
         $queues = array();
         foreach ($queueNames as $queueName) {
             $tmp = Mage::getModel('aoe_queue/queue', $queueName); /* @var $tmp Aoe_Queue_Model_Queue */

--- a/app/code/community/Aoe/Queue/Model/Cron.php
+++ b/app/code/community/Aoe/Queue/Model/Cron.php
@@ -1,9 +1,22 @@
 <?php
-
-class Aoe_Queue_Model_Cron {
-
-    public function processQueue() {
-
+/**
+ * AOE Queue - Queue implementation for Magento based on Zend Queue
+ *
+ * Cron model handles the processeing of queued jobs
+ * 
+ * @category Mage
+ * @package  Aoe_Queue
+ * @author   Fabrizio Branca
+ * @since    2012-11-09
+ */
+class Aoe_Queue_Model_Cron
+{
+    /**
+     * Processes the queue, executing as necessary
+     * @return array Statistics
+     */
+    public function processQueue()
+    {
         $starttime = microtime(true);
         $maxRuntime = 60; // TODO: read from configuration
 
@@ -23,7 +36,8 @@ class Aoe_Queue_Model_Cron {
 
         // process
         $statistics = array();
-        while (((microtime(true) - $starttime) < $maxRuntime) && count($queues)) { // while there are queues with messages left
+        // while there are queues with messages left
+        while (((microtime(true) - $starttime) < $maxRuntime) && count($queues)) {
             foreach ($queues as $queueName => $queue) {
                 $messages = $queue->receive(1);
                 if (count($messages) > 0) {
@@ -31,7 +45,9 @@ class Aoe_Queue_Model_Cron {
                         /* @var $message Aoe_Queue_Model_Message */
                         $message->execute();
                         $queue->deleteMessage($message);
-                        if (empty($statistics[$queueName])) { $statistics[$queueName] = 0; }
+                        if (empty($statistics[$queueName])) {
+                            $statistics[$queueName] = 0;
+                        }
                         $statistics[$queueName]++;
                         if ((microtime(true) - $starttime) > $maxRuntime) {
                             return $statistics;
@@ -46,5 +62,4 @@ class Aoe_Queue_Model_Cron {
 
         return $statistics;
     }
-
 }

--- a/app/code/community/Aoe/Queue/Model/Dummy.php
+++ b/app/code/community/Aoe/Queue/Model/Dummy.php
@@ -1,22 +1,25 @@
 <?php
-
 /**
- * Dummy model used in a unit test
+ * AOE Queue - Queue implementation for Magento based on Zend Queue
  *
- * @author Fabrizio Branca
- * @since 2012-11-07
+ * Dummy model used in a unit test
+ * 
+ * @category Mage
+ * @package  Aoe_Queue
+ * @author   Fabrizio Branca
+ * @since    2012-11-08
  */
-class Aoe_Queue_Model_Dummy {
-
+class Aoe_Queue_Model_Dummy
+{
     /**
      * Wrapper for str_repeat
      *
-     * @param $string
-     * @param $repeat
+     * @param  string $string
+     * @param  int    $repeat
      * @return string
      */
-    public function test($string, $repeat) {
+    public function test($string, $repeat)
+    {
         return str_repeat($string, $repeat);
     }
-
 }

--- a/app/code/community/Aoe/Queue/Model/Message.php
+++ b/app/code/community/Aoe/Queue/Model/Message.php
@@ -1,10 +1,13 @@
 <?php
-
 /**
- * Message model
+ * AOE Queue - Queue implementation for Magento based on Zend Queue
  *
- * @author Fabrizio Branca
- * @since  2012-11-07
+ * Message model handles execution and parsing of queue messages
+ * 
+ * @category Mage
+ * @package  Aoe_Queue
+ * @author   Fabrizio Branca
+ * @since    2012-11-07
  */
 class Aoe_Queue_Model_Message extends Zend_Queue_Message
 {
@@ -12,10 +15,11 @@ class Aoe_Queue_Model_Message extends Zend_Queue_Message
      * Execute this message
      *
      * @return mixed
+     * @throws Mage_Core_exception If no parameters were found
      */
     public function execute()
     {
-        $data = Zend_Json::decode($this->body);
+        $data     = Zend_Json::decode($this->body);
         $callback = $this->parseCallbackString($data['model']);
         if (!is_array($data['parameters'])) {
             Mage::throwException('No parameters found.');
@@ -26,14 +30,18 @@ class Aoe_Queue_Model_Message extends Zend_Queue_Message
     /**
      * Parses a callback string (like used in Mage_Cron) "model/class::method"
      *
-     * @param $callbackString
-     *
-     * @return callback
+     * @param  string $callbackString Dev class code and method, e.g. "model/class::method"
+     * @return array                  Array contains a Magento model and a function to call
+     * 
+     * @throws Mage_Core_Exception    If the $callbackString format was invalid
+     * @throws Mage_Core_Exception    If the callback method doesn't exist on the model
      */
     protected function parseCallbackString($callbackString)
     {
         if (!preg_match(Mage_Cron_Model_Observer::REGEX_RUN_MODEL, $callbackString, $run)) {
-            Mage::throwException(Mage::helper('cron')->__('Invalid model/method definition, expecting "model/class::method".'));
+            Mage::throwException(
+                Mage::helper('cron')->__('Invalid model/method definition, expecting "model/class::method".')
+            );
         }
         if (!($model = Mage::getModel($run[1])) || !method_exists($model, $run[2])) {
             Mage::throwException(Mage::helper('cron')->__('Invalid callback: %s::%s does not exist', $run[1], $run[2]));

--- a/app/code/community/Aoe/Queue/Model/Queue.php
+++ b/app/code/community/Aoe/Queue/Model/Queue.php
@@ -1,15 +1,22 @@
 <?php
-
 /**
- * Queue model
+ * AOE Queue - Queue implementation for Magento based on Zend Queue
  *
- * @author Fabrizio Branca
- * @since  2012-11-07
+ * Queue model handles the instantiation and creation of a queue item
+ * 
+ * @category Mage
+ * @package  Aoe_Queue
+ * @author   Fabrizio Branca
+ * @since    2012-11-07
  */
 class Aoe_Queue_Model_Queue extends Zend_Queue
 {
     /**
      * Constructor
+     * 
+     * @param  string $queueName
+     * 
+     * @throws Mage_Core_Exception If $queueName is not a string
      */
     public function __construct($queueName = 'default')
     {
@@ -45,20 +52,25 @@ class Aoe_Queue_Model_Queue extends Zend_Queue
     /**
      * Preventing devs from creating new queue with this class.
      *
-     * @param string $name
-     * @param null   $timeout
+     * @param  string   $name
+     * @param  null|int $timeout
      *
-     * @return false|void|Zend_Queue
+     * @return void
      * @throws Exception
      */
     public function createQueue($name, $timeout = null)
     {
-        throw new Exception('Creating a queue like this will create an object of class Zend_Queue instead of Aoe_Queue_Model_Queue. Please use the constructor instead.');
+        throw new Exception(
+            'Creating a queue like this will create an object of class Zend_Queue instead of Aoe_Queue_Model_Queue. '
+            . 'Please use the constructor instead.'
+        );
     }
 
     /**
-     * @param       $callback
-     * @param array $parameterArray
+     * Adds a task to the queue
+     * 
+     * @param string $callback       Dev class code and method, e.g. "model/class::method"
+     * @param array  $parameterArray Parameters to pass in for the task
      *
      * @return Zend_Queue_Message
      */

--- a/app/code/community/Aoe/Queue/etc/config.xml
+++ b/app/code/community/Aoe/Queue/etc/config.xml
@@ -60,7 +60,7 @@
     <default>
         <system>
             <aoe_queue>
-                <max_runtime>50</max_runtime>
+                <max_runtime>60</max_runtime>
                 <cron_expr>always</cron_expr>
             </aoe_queue>
         </system>

--- a/app/code/community/Aoe/Queue/etc/config.xml
+++ b/app/code/community/Aoe/Queue/etc/config.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * AOE Queue - Queue implementation for Magento based on Zend Queue
+ *
+ * @category Mage
+ * @package  Aoe_Queue
+ * @author   Fabrizio Branca
+ * @since    2012-11-07
+ */
+-->
 <config>
     <modules>
         <Aoe_Queue>

--- a/app/code/community/Aoe/Queue/etc/system.xml
+++ b/app/code/community/Aoe/Queue/etc/system.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0"?>
+<!--
+/**
+ * AOE Queue - Queue implementation for Magento based on Zend Queue
+ *
+ * @category Mage
+ * @package  Aoe_Queue
+ * @author   Fabrizio Branca
+ * @since    2012-11-07
+ */
+-->
 <config>
 	<sections>
 		<system>
@@ -10,9 +20,9 @@
 					<show_in_default>1</show_in_default>
 					<show_in_website>0</show_in_website>
 					<show_in_store>0</show_in_store>
-					<comment>The queue will be processed by a cron task. Configure the maximum runtime and the execution
+					<comment><![CDATA[The queue will be processed by a cron task. Configure the maximum runtime and the execution
 						frequency in a way the won't overlap. Also try Aoe_Scheduler's feature to define a separate
-						thread group for those tasks.
+						thread group for those tasks.]]>
 					</comment>
 					<fields>
 						<cron_expr translate="label">
@@ -30,8 +40,8 @@
 							<show_in_default>1</show_in_default>
 							<show_in_website>1</show_in_website>
 							<show_in_store>1</show_in_store>
-							<comment>Please note, that this is only an estimated value. The actual runtime can be longer
-								depending of the runtime of the current job.
+							<comment><![CDATA[Please note, that this is only an estimated value. The actual runtime can be longer
+								depending of the runtime of the current job.]]>
 							</comment>
 						</max_runtime>
 					</fields>

--- a/app/code/community/Aoe/Queue/sql/aoe_queue/mysql4-install-0.0.1.php
+++ b/app/code/community/Aoe/Queue/sql/aoe_queue/mysql4-install-0.0.1.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * AOE Queue - Queue implementation for Magento based on Zend Queue
+ *
+ * Set up the AOE Queue database tables
+ * 
+ * @category Mage
+ * @package  Aoe_Queue
+ * @author   Fabrizio Branca
+ * @since    2012-11-07
+ */
+?>
+<?php
 /* @var $this Mage_Core_Model_Resource_Setup */
 $this->startSetup();
 

--- a/tests/Aoe_Queue/QueueTestcase.php
+++ b/tests/Aoe_Queue/QueueTestcase.php
@@ -16,8 +16,8 @@ class PHPUnit_Extensions_Story_TestCase {}
  * @author Fabrizio Branca
  * @since 2012-11-07
  */
-class QueueTestcase extends PHPUnit_Framework_TestCase {
-
+class QueueTestcase extends PHPUnit_Framework_TestCase
+{
     /**
      * @var Aoe_Queue_Model_Queue
      */
@@ -28,19 +28,24 @@ class QueueTestcase extends PHPUnit_Framework_TestCase {
      */
     protected $_queueName;
 
-    public function setUp() {
+    public function setUp()
+    {
         $this->_queueName = 'testqueue_' . time();
 
         $queue = Mage::getModel('aoe_queue/queue', $this->_queueName); /* @var $queue Aoe_Queue_Model_Queue */
         $this->_queue = $queue;
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         $this->_queue->deleteQueue();
     }
 
-    public function testAddToQueueAndExecute() {
-
+    /**
+     * Should add a dummy task to the queue and execute it
+     */
+    public function testAddToQueueAndExecute()
+    {
         // adding task
         $this->_queue->addTask('aoe_queue/dummy::test', array('-+', '5'));
 
@@ -53,5 +58,4 @@ class QueueTestcase extends PHPUnit_Framework_TestCase {
             $this->assertEquals($expectedResult, $actualResult);
         }
     }
-
 }


### PR DESCRIPTION
Hi guys,

I propose a couple of changes:
- PHPdoc documentation block updates, adding some types, descriptions and missing `@throws` declarations
- Get max_runtime from configuration as the comment suggested as a TODO
- Reduced the length of some lines of code to under 120 characters

Cheers,
Robbie
